### PR TITLE
Optionally show rendered prompts and interpolated values in grid.

### DIFF
--- a/src/FunctionDoc.tsx
+++ b/src/FunctionDoc.tsx
@@ -123,7 +123,11 @@ const MiniParseq = ({ keyframes, fields }: MiniParseqProps) => {
         bpm={120}
         agGridStyle={{ width: '100%', minHeight: '50px', maxHeight: '500px', }}
         agGridProps={{ domLayout: 'autoHeight' }}
-        managedFields={fields} />
+        managedFields={fields}
+        renderedData={renderedData||null}
+        showPrompt={false}
+        showInterpolatedValues={true}
+        />
 
     const graph = graphableData && renderedData ? <ParseqGraph
         editingDisabled={true}

--- a/src/Labs.tsx
+++ b/src/Labs.tsx
@@ -131,7 +131,11 @@ const MiniParseq = ({ keyframes, fields }: MiniParseqProps) => {
         bpm={120}
         agGridStyle={{ width: '100%', minHeight: '50px', maxHeight: '500px', }}
         agGridProps={{ domLayout: 'autoHeight' }}
-        managedFields={fields} />
+        managedFields={fields}
+        renderedData={null}
+        showPrompt={false}
+        showInterpolatedValues={false}
+        />
 
     const graph = graphableData && renderedData ? <ParseqGraph
         editingDisabled={true}

--- a/src/components/PromptCellEditor.tsx
+++ b/src/components/PromptCellEditor.tsx
@@ -1,0 +1,52 @@
+
+import { Typography } from '@mui/material';
+import { experimental_extendTheme as extendTheme } from "@mui/material/styles";
+import {
+  forwardRef,
+  useImperativeHandle,
+  useRef
+} from 'react';
+import { themeFactory } from "../theme";
+
+// This is an "editor" from ag-grid's perspective, but is actually
+// a read-only view of the prompt at this cell.
+export const PromptCellEditor = forwardRef((props: any, ref) => {
+  const refText = useRef<HTMLDivElement | null>(null);
+  const theme = extendTheme(themeFactory());
+
+  /* Component Editor Lifecycle methods */
+  useImperativeHandle(ref, () => {
+    return {
+      getValue() {
+        return props.value;
+      },
+    };
+  });
+
+
+  const [positivePrompt, negativePrompt] = props.value.split('--neg');
+
+  return (
+    <div
+      ref={refText}
+      className='ag-custom-component-popup prompt-details'
+      style={{
+        border: '1px solid #00c',
+        padding: '2px',
+        background: theme.vars.palette.background.paper,
+        overflow: 'wrap',
+      }}
+    >
+      <div
+      style = {{userSelect: 'text'}}>
+      <Typography  fontSize={'1.1em'} fontFamily={'monospace'} color={theme.vars.palette.positive.main}> {positivePrompt}</Typography>
+      {
+        negativePrompt && <>
+          <Typography fontSize={'1.1em'} fontFamily={'monospace'} color={theme.vars.palette.text.primary }>--neg</Typography>
+          <Typography  fontSize={'1.1em'} fontFamily={'monospace'} color={theme.vars.palette.negative.main} >{negativePrompt}</Typography>
+        </>
+      }
+      </div>
+    </div>
+  );
+});

--- a/src/index.css
+++ b/src/index.css
@@ -56,3 +56,7 @@ p {
   font-size: 1em;
   line-height: .85em;
 }
+
+div.ag-popup-child:has(div.prompt-details) {
+  width: 50% !important
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,6 +11,7 @@ declare module "@mui/material/styles" {
         graphBackground: PaletteColor;
         graphFont: PaletteColor;
         gridInfoField: PaletteColor;
+        gridPromptField: PaletteColor;
         gridColSeparatorMajor: PaletteColor;
         gridColSeparatorMinor: PaletteColor;
         codeBackground: PaletteColor;
@@ -18,6 +19,7 @@ declare module "@mui/material/styles" {
         waveformEnd: PaletteColor;
         waveformProgressMaskStart: PaletteColor;
         waveformProgressMaskEnd: PaletteColor;
+        greyedText: PaletteColor;
     }
     interface PaletteOptions {
         negative: PaletteColor;
@@ -29,6 +31,7 @@ declare module "@mui/material/styles" {
         graphBackground: PaletteColor;
         graphFont: PaletteColor;
         gridInfoField: PaletteColor;
+        gridPromptField: PaletteColor;
         gridColSeparatorMajor: PaletteColor;
         gridColSeparatorMinor: PaletteColor;
         codeBackground: PaletteColor;
@@ -36,6 +39,7 @@ declare module "@mui/material/styles" {
         waveformEnd: PaletteColor;
         waveformProgressMaskStart: PaletteColor;
         waveformProgressMaskEnd: PaletteColor;
+        greyedText: PaletteColor;
 
     }
 }
@@ -56,6 +60,7 @@ export const themeFactory = (): CssVarsThemeOptions => {
                     graphBackground: palette.augmentColor({ color: { main: 'rgba(0, 0, 0, 0.1)' } }),
                     graphFont: palette.augmentColor({ color: { main: '#666' } }),
                     gridInfoField: palette.augmentColor({ color: { main: '#e5e5e5' } }),
+                    gridPromptField: palette.augmentColor({ color: { main: '#f5f5f5' } }),
                     gridColSeparatorMajor: palette.augmentColor({ color: { main: '#000' } }),
                     gridColSeparatorMinor: palette.augmentColor({ color: { main: '#ccc' } }),
                     codeBackground: palette.augmentColor({ color: { main: '#ccc' } }),
@@ -63,6 +68,7 @@ export const themeFactory = (): CssVarsThemeOptions => {
                     waveformEnd: palette.augmentColor({ color: { main: '#aaa' } }),
                     waveformProgressMaskStart: palette.augmentColor({ color: { main: '#aaa' } }),
                     waveformProgressMaskEnd: palette.augmentColor({ color: { main: '#ccc' } }),
+                    greyedText: palette.augmentColor({ color: { main: 'rgba(0, 0, 0, 0.275)' } }),
                     
                 }
             },
@@ -78,6 +84,7 @@ export const themeFactory = (): CssVarsThemeOptions => {
                     graphBackground: palette.augmentColor({ color: { main: 'rgba(255, 255, 255, 0.1)' } }),
                     graphFont: palette.augmentColor({ color: { main: '#ddd' } }),
                     gridInfoField: palette.augmentColor({ color: { main: '#444' } }),
+                    gridPromptField: palette.augmentColor({ color: { main: '#222' } }),                    
                     gridColSeparatorMajor: palette.augmentColor({ color: { main: '#fff' } }),
                     gridColSeparatorMinor: palette.augmentColor({ color: { main: '#555' } }),
                     codeBackground: palette.augmentColor({ color: { main: '#666' } }),
@@ -85,6 +92,7 @@ export const themeFactory = (): CssVarsThemeOptions => {
                     waveformEnd: palette.augmentColor({ color: { main: '#aaa' } }),
                     waveformProgressMaskStart: palette.augmentColor({ color: { main: '#bbb' } }),
                     waveformProgressMaskEnd: palette.augmentColor({ color: { main: '#555' } }),
+                    greyedText: palette.augmentColor({ color: { main: 'rgba(255, 255, 255, 0.2)' } }),
                 }
             }
         }


### PR DESCRIPTION
This introduces a change to the grid whereby you can see some rendered data at each keyframe,  such as the prompts and interpolated values.

![image](https://github.com/rewbs/sd-parseq/assets/74455/b3f05730-7b5f-435c-8722-4644ec234ac8)


Note: some of the grid header code is getting really messy (duplication, nested conditionals etc...); need to address that at some stage.